### PR TITLE
Add onboarding features and intro narration

### DIFF
--- a/src/features/Meta/state/MetaSlice.ts
+++ b/src/features/Meta/state/MetaSlice.ts
@@ -16,6 +16,8 @@ const initialState: MetaState = {
   saveInProgress: false,
   loadInProgress: false,
   error: null,
+  // New intro flag
+  hasSeenIntro: false,
 };
 
 const metaSlice = createSlice({
@@ -37,6 +39,9 @@ const metaSlice = createSlice({
     setIsInProximityToNPC: (state, action: PayloadAction<boolean>) => {
       state.isInProximityToNPC = action.payload;
     },
+    setHasSeenIntro: (state, action: PayloadAction<boolean>) => {
+      (state as any).hasSeenIntro = action.payload;
+    },
   },
 });
 
@@ -45,7 +50,8 @@ export const {
   updateGameMetadata,
   setGameVersion,
   resetSessionStartTime,
-  setIsInProximityToNPC
+  setIsInProximityToNPC,
+  setHasSeenIntro
 } = metaSlice.actions;
 
 // FIXED: Corrected and cleaned up selectors to match the final MetaState interface.
@@ -56,5 +62,6 @@ export const selectIsImported = (state: RootState) => state.meta.isImported;
 export const selectGameVersion = (state: RootState) => state.meta.gameVersion;
 export const selectSessionStartTime = (state: RootState) => state.meta.sessionStartTime;
 export const selectIsInProximityToNPC = (state: RootState) => state.meta.isInProximityToNPC;
+export const selectHasSeenIntro = (state: RootState) => (state.meta as any).hasSeenIntro === true;
 
 export default metaSlice.reducer;

--- a/src/features/Meta/state/MetaSlice.ts
+++ b/src/features/Meta/state/MetaSlice.ts
@@ -40,7 +40,7 @@ const metaSlice = createSlice({
       state.isInProximityToNPC = action.payload;
     },
     setHasSeenIntro: (state, action: PayloadAction<boolean>) => {
-      (state as any).hasSeenIntro = action.payload;
+      state.hasSeenIntro = action.payload;
     },
   },
 });
@@ -62,6 +62,6 @@ export const selectIsImported = (state: RootState) => state.meta.isImported;
 export const selectGameVersion = (state: RootState) => state.meta.gameVersion;
 export const selectSessionStartTime = (state: RootState) => state.meta.sessionStartTime;
 export const selectIsInProximityToNPC = (state: RootState) => state.meta.isInProximityToNPC;
-export const selectHasSeenIntro = (state: RootState) => (state.meta as any).hasSeenIntro === true;
+export const selectHasSeenIntro = (state: RootState) => state.meta.hasSeenIntro === true;
 
 export default metaSlice.reducer;

--- a/src/features/Meta/state/MetaTypes.ts
+++ b/src/features/Meta/state/MetaTypes.ts
@@ -16,4 +16,5 @@ export interface MetaState {
   saveInProgress: boolean;
   loadInProgress: boolean;
   error: string | null;
+  hasSeenIntro: boolean;
 }

--- a/src/features/NPCs/components/containers/NPCListView.tsx
+++ b/src/features/NPCs/components/containers/NPCListView.tsx
@@ -32,6 +32,7 @@ import {
 import { Search, Person, Star, ViewList, ViewModule } from '@mui/icons-material';
 import { useAppSelector, useAppDispatch } from '../../../../app/hooks';
 import { selectNPCs, selectDiscoveredNPCs } from '../../state/NPCSelectors';
+import { selectHasSeenIntro } from '../../../Meta/state/MetaSlice';
 import { selectPlayerLocation } from '../../../Player/state/PlayerSelectors';
 import { NPC } from '../../state/NPCTypes';
 import { initializeNPCsThunk } from '../..';
@@ -52,6 +53,7 @@ export const NPCListView: React.FC<NPCListViewProps> = ({
   const npcs = useAppSelector(selectNPCs);
   const discoveredNPCIds = useAppSelector(selectDiscoveredNPCs);
   const playerLocation = useAppSelector(selectPlayerLocation);
+  const hasSeenIntro = useAppSelector(selectHasSeenIntro);
   const dispatch = useAppDispatch();
   
   const [searchTerm, setSearchTerm] = useState('');
@@ -228,11 +230,12 @@ export const NPCListView: React.FC<NPCListViewProps> = ({
           viewMode === 'grid' ? (
             <Grid container spacing={2}>
               {filteredAndSortedNPCs.map(npc => (
-                <NPCListCard 
-                  key={npc.id} 
-                  npc={npc} 
-                  onSelectNPC={onSelectNPC} 
-                  isSelected={selectedNPCId === npc.id} 
+                <NPCListCard
+                  key={npc.id}
+                  npc={npc}
+                  onSelectNPC={onSelectNPC}
+                  isSelected={selectedNPCId === npc.id}
+                  isGlowing={!hasSeenIntro && filteredAndSortedNPCs.length === 1}
                 />
               ))}
             </Grid>

--- a/src/features/NPCs/components/containers/NPCPanelContainer.tsx
+++ b/src/features/NPCs/components/containers/NPCPanelContainer.tsx
@@ -9,7 +9,7 @@ import { useAppSelector, useAppDispatch } from '../../../../app/hooks';
 // FIXED: Import the correct thunk for creating a copy
 import { selectNPCById, selectNPCLoading, selectNPCError } from '../../state/NPCSelectors';
 import { initializeNPCsThunk } from '../../'; // Corrected import path
-import { Box, Paper, Typography, Button, Tabs, Tab, CircularProgress } from '@mui/material';
+import { Box, Paper, Typography, Button, Tabs, Tab, CircularProgress, Tooltip } from '@mui/material';
 import { CreateCopyModal } from '../../../Copy/components/ui/CreateCopyModal';
 import NPCOverviewTab from '../ui/tabs/NPCOverviewTab';
 import NPCTradeTab from '../ui/tabs/NPCTradeTab';
@@ -127,9 +127,15 @@ export const NPCPanelContainer: React.FC<NPCPanelContainerProps> = () => {
         <Box sx={{ borderBottom: 1, borderColor: 'divider', mt: 2 }}>
         <Tabs value={currentTab} onChange={handleTabChange} aria-label="npc details tabs">
           <Tab label="Overview" id="npc-tab-0" />
-          <Tab label="Quests" id="npc-tab-1" />
-          <Tab label="Trade" id="npc-tab-2" />
-          <Tab label="Traits" id="npc-tab-3" />
+          <Tooltip title={npc.affinity < 20 ? 'Requires Affinity 20' : ''} disableHoverListener={npc.affinity >= 20}>
+            <span><Tab disabled={npc.affinity < 20} label="Quests" id="npc-tab-1" /></span>
+          </Tooltip>
+          <Tooltip title={npc.affinity < 40 ? 'Requires Affinity 40' : ''} disableHoverListener={npc.affinity >= 40}>
+            <span><Tab disabled={npc.affinity < 40} label="Trade" id="npc-tab-2" /></span>
+          </Tooltip>
+          <Tooltip title={npc.connectionDepth < 1 ? 'Requires Connection Depth 1' : ''} disableHoverListener={npc.connectionDepth >= 1}>
+            <span><Tab disabled={npc.connectionDepth < 1} label="Traits" id="npc-tab-3" /></span>
+          </Tooltip>
         </Tabs>
       </Box>
       <TabPanel value={currentTab} index={0}>

--- a/src/features/NPCs/components/ui/NPCHeader.tsx
+++ b/src/features/NPCs/components/ui/NPCHeader.tsx
@@ -10,7 +10,8 @@ import {
   Avatar,
   Chip,
   LinearProgress,
-  Paper
+  Paper,
+  Button
 } from '@mui/material';
 import {
   Person as PersonIcon,
@@ -19,13 +20,16 @@ import {
 } from '@mui/icons-material';
 import type { NPC } from '../../state/NPCTypes';
 // Import getTierBenefits for comprehensive tier information
-import { getTierBenefits, RELATIONSHIP_TIERS } from '../../../../config/relationshipConstants'; 
+import { getTierBenefits } from '../../../../config/relationshipConstants'; 
+import { useAppDispatch } from '../../../../app/hooks';
+import { updateNPCRelationshipThunk } from '../../state/NPCThunks';
 
 interface NPCHeaderProps {
   npc: NPC;
 }
 
 const NPCHeader: React.FC<NPCHeaderProps> = ({ npc }) => {
+  const dispatch = useAppDispatch();
   const currentTierInfo = getTierBenefits(npc.affinity);
   const currentTierName = currentTierInfo.name;
   
@@ -52,6 +56,11 @@ const NPCHeader: React.FC<NPCHeaderProps> = ({ npc }) => {
     progressPercentageInTier = 100;
     progressLabel = `${currentTierName} (Max)`;
   }
+
+  const handleBond = () => {
+    // Simple vertical-slice friendly bonding: +5 affinity per click
+    dispatch(updateNPCRelationshipThunk({ npcId: npc.id, change: 5, reason: 'Bonding' }));
+  };
 
   return (
     <Paper 
@@ -123,7 +132,7 @@ const NPCHeader: React.FC<NPCHeaderProps> = ({ npc }) => {
         </Box>
 
         {/* Relationship Info */}
-        <Box sx={{ minWidth: 200 }}>
+  <Box sx={{ minWidth: 200, display: 'flex', flexDirection: 'column', gap: 1 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
             <FavoriteIcon color="action" />
             <Typography variant="subtitle2">
@@ -158,10 +167,19 @@ const NPCHeader: React.FC<NPCHeaderProps> = ({ npc }) => {
           </Typography>
 
           {npc.connectionDepth !== undefined && (
-            <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
               Connection Depth: {npc.connectionDepth.toFixed(1)}
             </Typography>
           )}
+          <Button
+            variant="contained"
+            size="small"
+            color="secondary"
+            onClick={handleBond}
+            sx={{ mt: 0.5, textTransform: 'none' }}
+          >
+            Bond (+5)
+          </Button>
         </Box>
       </Box>
     </Paper>

--- a/src/features/NPCs/components/ui/NPCListCard.tsx
+++ b/src/features/NPCs/components/ui/NPCListCard.tsx
@@ -20,9 +20,10 @@ interface NPCListCardProps {
   npc: NPC;
   onSelectNPC: (npcId: string) => void;
   isSelected: boolean;
+  isGlowing?: boolean;
 }
 
-export const NPCListCard: React.FC<NPCListCardProps> = React.memo(({ npc, onSelectNPC, isSelected }) => {
+export const NPCListCard: React.FC<NPCListCardProps> = React.memo(({ npc, onSelectNPC, isSelected, isGlowing }) => {
   const currentTier = getCentralRelationshipTier(npc.affinity);
 
   return (
@@ -34,10 +35,17 @@ export const NPCListCard: React.FC<NPCListCardProps> = React.memo(({ npc, onSele
           borderColor: isSelected ? 'primary.main' : 'divider',
           cursor: 'pointer',
           transition: 'all 0.2s',
+          boxShadow: isGlowing ? '0 0 0 0 rgba(255,255,255,0.7)' : undefined,
+          animation: isGlowing ? 'glowPulse 2s infinite' : undefined,
           '&:hover': {
             borderColor: 'primary.light',
             transform: 'translateY(-2px)',
             boxShadow: 3,
+          },
+          '@keyframes glowPulse': {
+            '0%': { boxShadow: '0 0 0 0 rgba(255,255,255,0.5)' },
+            '70%': { boxShadow: '0 0 12px 4px rgba(255,255,255,0.2)' },
+            '100%': { boxShadow: '0 0 0 0 rgba(255,255,255,0)' },
           },
         }}
         onClick={() => onSelectNPC(npc.id)}

--- a/src/features/NPCs/components/ui/tabs/NPCOverviewTab.tsx
+++ b/src/features/NPCs/components/ui/tabs/NPCOverviewTab.tsx
@@ -3,7 +3,7 @@
  * @description Overview tab showing basic NPC information and available interactions
  */
 
-import React, { useEffect, useMemo, useCallback } from 'react';
+import React, { useEffect, useMemo, useCallback, useState } from 'react';
 import {
   Box,
   Typography,
@@ -43,6 +43,7 @@ import {
 } from '../../../../Traits/state/TraitsSelectors';
 import { fetchTraitsThunk } from '../../../../Traits/state/TraitThunks';
 import { equipTrait } from '../../../../Player/state/PlayerSlice';
+import { updateNPCRelationshipThunk } from '../../../state/NPCThunks';
 import { recalculateStatsThunk } from '../../../../Player/state/PlayerThunks';
 import type { NPC } from '../../../state/NPCTypes';
 import type { Trait } from '../../../../Traits/state/TraitsTypes';
@@ -53,6 +54,7 @@ interface NPCOverviewTabProps {
 
 const NPCOverviewTab: React.FC<NPCOverviewTabProps> = ({ npc }) => {
   const dispatch = useAppDispatch();
+  const [cooldown, setCooldown] = useState(false);
 
   const allTraits = useAppSelector(selectTraits);
   const traitsLoading = useAppSelector(selectTraitLoading);
@@ -89,6 +91,21 @@ const NPCOverviewTab: React.FC<NPCOverviewTabProps> = ({ npc }) => {
 
   return (
     <Box sx={{ p: 3 }}>
+      <Box sx={{ mb: 3 }}>
+        <Button
+          variant="contained"
+          color="secondary"
+          disabled={cooldown}
+          onClick={() => {
+            if (cooldown) return;
+            setCooldown(true);
+            dispatch(updateNPCRelationshipThunk({ npcId: npc.id, change: 10, reason: 'Interaction' }));
+            setTimeout(() => setCooldown(false), 1200);
+          }}
+        >
+          {cooldown ? 'Cooling...' : 'Interact'}
+        </Button>
+      </Box>
       <Grid container spacing={3}>
         <Grid item xs={12} md={6}>
           <Card>

--- a/src/features/NPCs/index.ts
+++ b/src/features/NPCs/index.ts
@@ -48,6 +48,7 @@ export {
   updateNPCConnectionDepthThunk,
   processNPCInteractionThunk,
   discoverNPCThunk,
+  newGameSeedNPCsThunk,
   shareTraitWithNPCThunk,
 } from './state/NPCThunks';
 

--- a/src/features/NPCs/state/NPCSlice.ts
+++ b/src/features/NPCs/state/NPCSlice.ts
@@ -19,7 +19,7 @@ import { initializeNPCsThunk } from './NPCThunks';
 import { TRADING } from '../../../constants/gameConstants';
 
 const initialState: NPCState = {
-  npcs: {},
+  npcs: {}, // start empty; first NPC discovered via new game logic
   discoveredNPCs: [],
   currentInteraction: null,
   dialogueHistory: [],

--- a/src/features/NPCs/state/NPCThunks.ts
+++ b/src/features/NPCs/state/NPCThunks.ts
@@ -119,10 +119,8 @@ export const updateNPCRelationshipThunk = createAsyncThunk(
         connectionDepthIncrease = Math.floor(newAffinity / 100);
         newAffinity = newAffinity % 100;
 
-  const oldDepth = npc.connectionDepth || 0;
   dispatch(increaseConnectionDepth({ npcId, amount: connectionDepthIncrease }));
-  const newDepth = oldDepth + connectionDepthIncrease;
-  dispatch(addNotification({ type: 'success', message: `Your bond with ${npc.name} has deepened. Essence now flows more strongly. (Depth ${newDepth})` }));
+  dispatch(addNotification({ type: 'success', message: `Your bond with ${npc.name} has deepened. Essence now flows more strongly. (Depth ${(npc.connectionDepth || 0) + connectionDepthIncrease})` }));
     }
     
     dispatch(setAffinity({ npcId, value: newAffinity }));

--- a/src/features/NPCs/state/NPCThunks.ts
+++ b/src/features/NPCs/state/NPCThunks.ts
@@ -6,7 +6,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import type { RootState } from '../../../app/store';
 import type { NPC, InteractionResult, RelationshipChangeEntry } from './NPCTypes';
 import { updateEssenceGenerationRateThunk } from '../../Essence';
-import { setAffinity, increaseConnectionDepth, addRelationshipChangeEntry, updateNpcConnectionDepth, debugUnlockAllSharedSlots as debugUnlockAllSharedSlotsAction, setNPCSharedTraitInSlot, addDialogueEntry, setDialogueNodes, incrementNpcShopItem, markNpcRestock, addAvailableQuestToNPC } from './NPCSlice';
+import { setAffinity, increaseConnectionDepth, addRelationshipChangeEntry, updateNpcConnectionDepth, debugUnlockAllSharedSlots as debugUnlockAllSharedSlotsAction, setNPCSharedTraitInSlot, addDialogueEntry, setDialogueNodes, incrementNpcShopItem, markNpcRestock, addAvailableQuestToNPC, setNPCs } from './NPCSlice';
 import { addNotification } from '../../../shared/state/NotificationSlice';
 import { spendGold, addAvailableAttributePoints, addAvailableSkillPoints } from '../../Player/state/PlayerSlice';
 import { TRADING } from '../../../constants/gameConstants';
@@ -55,6 +55,44 @@ export const discoverNPCThunk = createAsyncThunk(
   'npcs/discoverNPC',
   async (npcId: string) => {
     return npcId;
+  }
+);
+
+/**
+ * NEW GAME THUNK: Seeds the world with only the Elder Willow NPC in a stripped-down state for onboarding.
+ * Fetches the full NPC dataset, extracts npc_elder_willow, normalizes starting values, and dispatches setNPCs.
+ */
+export const newGameSeedNPCsThunk = createAsyncThunk(
+  'npcs/newGameSeed',
+  async (_, { dispatch }) => {
+    try {
+      const res = await fetch('/data/npcs.json');
+      if (!res.ok) throw new Error('Failed to fetch npc data');
+      const data: Record<string, NPC> = await res.json();
+      const elder = data['npc_elder_willow'];
+      if (!elder) throw new Error('Elder Willow NPC definition missing');
+      // Override starting relationship values for onboarding clarity
+      const seeded: Record<string, NPC> = {
+        npc_elder_willow: {
+          ...elder,
+          affinity: 0,
+          connectionDepth: 0,
+          loyalty: 0,
+          isDiscovered: true,
+          discoveredAt: Date.now(),
+          availableQuests: [],
+          completedQuests: [],
+          availableDialogues: elder.availableDialogues?.slice(0,1) || [],
+          completedDialogues: [],
+        }
+      } as Record<string, NPC>;
+      dispatch(setNPCs(seeded));
+      await dispatch(updateEssenceGenerationRateThunk());
+      return Object.keys(seeded);
+    } catch (e) {
+      console.error('newGameSeedNPCsThunk failed', e);
+      return [] as string[];
+    }
   }
 );
 

--- a/src/features/NPCs/state/NPCThunks.ts
+++ b/src/features/NPCs/state/NPCThunks.ts
@@ -81,7 +81,10 @@ export const updateNPCRelationshipThunk = createAsyncThunk(
         connectionDepthIncrease = Math.floor(newAffinity / 100);
         newAffinity = newAffinity % 100;
 
-        dispatch(increaseConnectionDepth({ npcId, amount: connectionDepthIncrease }));
+  const oldDepth = npc.connectionDepth || 0;
+  dispatch(increaseConnectionDepth({ npcId, amount: connectionDepthIncrease }));
+  const newDepth = oldDepth + connectionDepthIncrease;
+  dispatch(addNotification({ type: 'success', message: `Your bond with ${npc.name} has deepened. Essence now flows more strongly. (Depth ${newDepth})` }));
     }
     
     dispatch(setAffinity({ npcId, value: newAffinity }));

--- a/src/features/Player/components/ui/StatDisplay.tsx
+++ b/src/features/Player/components/ui/StatDisplay.tsx
@@ -18,6 +18,8 @@ export interface StatDisplayProps {
   maxValue?: number;
   color?: 'primary' | 'secondary' | 'error' | 'warning' | 'info' | 'success';
   size?: 'small' | 'medium' | 'large';
+  delta?: number; // optional recent change
+  highlightDeltaMs?: number; // how long to highlight in ms
 }
 
 /**
@@ -31,7 +33,18 @@ export const StatDisplay: React.FC<StatDisplayProps> = React.memo(({
   maxValue,
   color = 'primary',
   size = 'medium',
+  delta = 0,
+  highlightDeltaMs = 2000,
 }) => {
+  const [flash, setFlash] = React.useState<'up' | 'down' | 'none'>('none');
+
+  React.useEffect(() => {
+    if (delta && delta !== 0) {
+      setFlash(delta > 0 ? 'up' : 'down');
+      const t = setTimeout(() => setFlash('none'), highlightDeltaMs);
+      return () => clearTimeout(t);
+    }
+  }, [delta, highlightDeltaMs]);
   const numericValue = typeof value === 'string' ? parseFloat(value) || 0 : value;
   const displayValue = typeof value === 'string' ? value : value.toLocaleString();
 
@@ -73,6 +86,18 @@ export const StatDisplay: React.FC<StatDisplayProps> = React.memo(({
         >
           {displayValue}{unit}
         </Typography>
+        {flash !== 'none' && typeof value === 'number' && (
+          <Typography
+            variant="caption"
+            sx={{
+              color: flash === 'up' ? 'success.main' : 'error.main',
+              fontWeight: 600,
+              transition: 'opacity 0.4s',
+            }}
+          >
+            {flash === 'up' ? '+' : ''}{delta?.toFixed?.(delta % 1 ? 2 : 0)}
+          </Typography>
+        )}
 
         {showProgress && maxValue && typeof value === 'number' && (
           <Box sx={{ flex: 1, ml: 1 }}>

--- a/src/features/Player/components/ui/StatDisplay.tsx
+++ b/src/features/Player/components/ui/StatDisplay.tsx
@@ -36,9 +36,9 @@ export const StatDisplay: React.FC<StatDisplayProps> = React.memo(({
   delta = 0,
   highlightDeltaMs = 2000,
 }) => {
-  const [flash, setFlash] = React.useState<'up' | 'down' | 'none'>('none');
+  const [flash, setFlash] = useState<'up' | 'down' | 'none'>('none');
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (delta && delta !== 0) {
       setFlash(delta > 0 ? 'up' : 'down');
       const t = setTimeout(() => setFlash('none'), highlightDeltaMs);

--- a/src/features/Player/components/ui/StatDisplay.tsx
+++ b/src/features/Player/components/ui/StatDisplay.tsx
@@ -95,7 +95,7 @@ export const StatDisplay: React.FC<StatDisplayProps> = React.memo(({
               transition: 'opacity 0.4s',
             }}
           >
-            {flash === 'up' ? '+' : ''}{delta?.toFixed?.(delta % 1 ? 2 : 0)}
+            {flash === 'up' ? '+' : ''}{delta.toFixed(delta % 1 ? 2 : 0)}
           </Typography>
         )}
 

--- a/src/features/Player/hooks/useStatDiffs.ts
+++ b/src/features/Player/hooks/useStatDiffs.ts
@@ -31,8 +31,15 @@ export function useStatDiffs<T extends Record<string, number | undefined>>(stats
         delta,
         direction: delta > 0 ? 'up' : delta < 0 ? 'down' : 'none'
       });
+      // Incrementally update prevRef.current
+      prev[k] = vRaw;
     }
-    prevRef.current = Object.fromEntries(Object.entries(stats).filter(([, v]) => typeof v === 'number') as [string, number][]);
+    // Remove keys from prevRef.current that are no longer present or not a number
+    for (const k of Object.keys(prev)) {
+      if (!(k in stats) || typeof stats[k] !== 'number') {
+        delete prev[k];
+      }
+    }
     setDiffs(nextDiffs);
   }, [stats]);
 

--- a/src/features/Player/hooks/useStatDiffs.ts
+++ b/src/features/Player/hooks/useStatDiffs.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState } from 'react';
+
+export interface StatDiff {
+  key: string;
+  current: number;
+  previous: number;
+  delta: number;
+  direction: 'up' | 'down' | 'none';
+}
+
+/**
+ * Hook: useStatDiffs
+ * Tracks deltas between successive stat objects (flat number maps) and returns annotated diffs.
+ * Only flags a direction if delta != 0. Useful for transient highlighting.
+ */
+export function useStatDiffs<T extends Record<string, number | undefined>>(stats: T) {
+  const prevRef = useRef<Record<string, number>>({});
+  const [diffs, setDiffs] = useState<StatDiff[]>([]);
+
+  useEffect(() => {
+    const prev = prevRef.current;
+    const nextDiffs: StatDiff[] = [];
+    for (const [k, vRaw] of Object.entries(stats)) {
+      if (typeof vRaw !== 'number') continue;
+      const prevVal = prev[k] ?? vRaw;
+      const delta = vRaw - prevVal;
+      nextDiffs.push({
+        key: k,
+        current: vRaw,
+        previous: prevVal,
+        delta,
+        direction: delta > 0 ? 'up' : delta < 0 ? 'down' : 'none'
+      });
+    }
+    prevRef.current = Object.fromEntries(Object.entries(stats).filter(([, v]) => typeof v === 'number') as [string, number][]);
+    setDiffs(nextDiffs);
+  }, [stats]);
+
+  return diffs;
+}
+
+/** Helper to get a specific stat diff quickly */
+export function useStatDiff(key: string, diffs: StatDiff[]) {
+  return diffs.find(d => d.key === key);
+}

--- a/src/features/Player/state/PlayerSlice.ts
+++ b/src/features/Player/state/PlayerSlice.ts
@@ -72,7 +72,7 @@ const initialState: PlayerState = {
   totalPlaytime: 0,
   isAlive: true,
   location: 'City Center',
-  gold: 100,
+  gold: 25,
 };
 
 /**

--- a/src/features/Traits/state/TraitsSelectors.ts
+++ b/src/features/Traits/state/TraitsSelectors.ts
@@ -75,7 +75,7 @@ export const selectResonanceETAs = createSelector(
       if (permanentTraits.includes(id)) continue; // skip already permanent
       const trait = allTraits[id];
       if (!trait) continue;
-      const cost = (trait as any).essenceCost || 0;
+      const cost = trait.essenceCost ?? 0;
       if (cost <= 0) continue;
       const remaining = Math.max(0, cost - currentEssence);
       const etaSeconds = remaining === 0 ? 0 : (generationRate > 0 ? remaining / generationRate : Number.POSITIVE_INFINITY);

--- a/src/features/Traits/state/TraitsSelectors.ts
+++ b/src/features/Traits/state/TraitsSelectors.ts
@@ -54,3 +54,33 @@ export const selectTraitPresetById = createSelector(
   [selectTraitPresets, (state: RootState, presetId: string) => presetId],
   (presets, presetId) => presets.find((preset: TraitPreset) => preset.id === presetId) || null
 );
+
+/**
+ * Selector: Resonance ETAs
+ * Computes estimated time (seconds) until the player can afford resonance for discovered, non-permanent traits.
+ * Requires: essence slice with currentEssence & generationRate, player slice with permanentTraits, trait essenceCost.
+ * Returns sorted array by ETA ascending. If generationRate is 0, ETA defaults to Infinity for unaffordable traits.
+ */
+export const selectResonanceETAs = createSelector(
+  [
+    (state: RootState) => state.essence.currentEssence,
+    (state: RootState) => state.essence.generationRate,
+    selectDiscoveredTraits,
+    selectTraits,
+    (state: RootState) => state.player.permanentTraits
+  ],
+  (currentEssence, generationRate, discoveredTraitIds, allTraits, permanentTraits) => {
+    const results: { traitId: string; traitName: string; cost: number; etaSeconds: number }[] = [];
+    for (const id of discoveredTraitIds) {
+      if (permanentTraits.includes(id)) continue; // skip already permanent
+      const trait = allTraits[id];
+      if (!trait) continue;
+      const cost = (trait as any).essenceCost || 0;
+      if (cost <= 0) continue;
+      const remaining = Math.max(0, cost - currentEssence);
+      const etaSeconds = remaining === 0 ? 0 : (generationRate > 0 ? remaining / generationRate : Number.POSITIVE_INFINITY);
+      results.push({ traitId: id, traitName: trait.name || id, cost, etaSeconds });
+    }
+    return results.sort((a, b) => a.etaSeconds - b.etaSeconds);
+  }
+);

--- a/src/layout/components/GameLayout.tsx
+++ b/src/layout/components/GameLayout.tsx
@@ -6,6 +6,9 @@ import { useLayoutState } from '../hooks/useLayoutState';
 import { VerticalNavBar } from './VerticalNavBar/VerticalNavBar';
 import { MainContentArea } from './MainContentArea';
 import { Outlet } from 'react-router-dom';
+import IntroNarration from '../../shared/components/ui/IntroNarration';
+import { useAppSelector } from '../../app/hooks';
+import { selectHasSeenIntro } from '../../features/Meta/state/MetaSlice';
 import { useNpcShopRestock } from '../../features/NPCs/hooks/useNpcShopRestock';
 
 /**
@@ -16,6 +19,7 @@ export const GameLayout: React.FC = React.memo(() => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const dispatch = useAppDispatch();
+  const hasSeenIntro = useAppSelector(selectHasSeenIntro);
 
   // Automatically start the game loop when the layout mounts
   useEffect(() => {
@@ -79,6 +83,7 @@ export const GameLayout: React.FC = React.memo(() => {
           changeTab={setActiveTab}
         >
           <Outlet />
+          {!hasSeenIntro && <IntroNarration />}
         </MainContentArea>
       </Box>
     </Box>

--- a/src/layout/components/Header.tsx
+++ b/src/layout/components/Header.tsx
@@ -4,7 +4,14 @@ import {
   Toolbar, 
   Typography, 
   Box, 
+  Chip,
+  Tooltip,
+  Stack
 } from '@mui/material';
+import { ElectricBolt as EssenceIcon } from '@mui/icons-material';
+import { useAppSelector } from '../../app/hooks';
+import { selectCurrentEssence, selectGenerationRate } from '../../features/Essence/state/EssenceSelectors';
+import { selectResonanceETAs } from '../../features/Traits/state/TraitsSelectors';
 
 /**
  * Props for the Header component
@@ -26,25 +33,50 @@ interface HeaderProps {
  *   <Header title="My Game" />
  * )
  */
-const Header: React.FC<HeaderProps> = ({ 
-  title = 'Incremental RPG', 
-}) => {
-    return (
-        <AppBar position="static" elevation={1}>
-            <Toolbar variant="dense">
-                <Typography 
-                  variant="h6" 
-                  component="div" 
-                  sx={{ 
-                    flexGrow: 1, 
-                    textAlign: { xs: 'center', md: 'left' }
-                  }}
-                >
-                    {title}
-                </Typography>
-            </Toolbar>
-        </AppBar>
-    );
+const Header: React.FC<HeaderProps> = ({ title = 'Incremental RPG' }) => {
+  // Essence HUD data
+  const essence = useAppSelector(selectCurrentEssence);
+  const ratePerSec = useAppSelector(selectGenerationRate);
+  const resonanceEtas = useAppSelector(selectResonanceETAs);
+
+  const nextResonance = resonanceEtas[0];
+
+  return (
+    <AppBar position="static" elevation={1}>
+      <Toolbar variant="dense" sx={{ gap: 2 }}>
+        <Typography
+          variant="h6"
+          component="div"
+          sx={{ flexGrow: 1, textAlign: { xs: 'center', md: 'left' } }}
+        >
+          {title}
+        </Typography>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Tooltip title={`Passive rate: ${(ratePerSec || 0).toFixed(2)}/s`} arrow>
+            <Chip
+              color="primary"
+              icon={<EssenceIcon />}
+              label={`${essence.toLocaleString()} Essence`}
+              size="small"
+            />
+          </Tooltip>
+          {nextResonance && (
+            <Tooltip
+              title={`ETA to resonate '${nextResonance.traitName}': ${nextResonance.etaSeconds.toFixed(0)}s`}
+              arrow
+            >
+              <Chip
+                variant="outlined"
+                color="secondary"
+                label={`Next Resonance: ${nextResonance.etaSeconds < 9999 ? `${nextResonance.etaSeconds.toFixed(0)}s` : '—'}`}
+                size="small"
+              />
+            </Tooltip>
+          )}
+        </Stack>
+      </Toolbar>
+    </AppBar>
+  );
 };
 
 export default Header;

--- a/src/pages/MainMenu/hooks/useGameActions.ts
+++ b/src/pages/MainMenu/hooks/useGameActions.ts
@@ -5,6 +5,9 @@ import { DialogState } from './useDialogManager';
 import { loadSavedGame } from '../../../shared/utils/saveUtils'; // Import load function
 import { useAppDispatch } from '../../../app/hooks'; // Import typed dispatch
 import { replaceState, RootState } from '../../../app/store'; // Import action creator and RootState type
+import { resetPlayerState } from '../../../features/Player/state/PlayerSlice';
+import { setHasSeenIntro } from '../../../features/Meta/state/MetaSlice';
+import { newGameSeedNPCsThunk } from '../../../features/NPCs';
 
 interface GameActionsProps {
   mostRecentSave: SavedGame | null;
@@ -31,8 +34,12 @@ export function useGameActions({
   const dispatch = useAppDispatch(); // Use typed dispatch
 
   const handleNewGame = useCallback(() => {
-    navigate('/game');
-  }, [navigate]);
+    // Reset key slices (player) and intro flag, then seed onboarding NPC and navigate directly to NPCs view
+    dispatch(resetPlayerState());
+    dispatch(setHasSeenIntro(false));
+    dispatch(newGameSeedNPCsThunk());
+    navigate('/game/npcs');
+  }, [navigate, dispatch]);
 
   const handleLoadGame = useCallback(async (saveId: string) => {
     console.log('Attempting to load game:', saveId);

--- a/src/shared/components/ui/IntroNarration.tsx
+++ b/src/shared/components/ui/IntroNarration.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { Backdrop, Box, Paper, Typography, Button, Fade } from '@mui/material';
+import { useAppDispatch, useAppSelector } from '../../../app/hooks';
+import { setHasSeenIntro, selectHasSeenIntro } from '../../../features/Meta/state/MetaSlice';
+
+const defaultLines = [
+  "Impact. Systems flicker. Memory fragments.",
+  "Alone in the wreckage—only a single presence pulses faintly nearby.",
+  "Connection is more than survival. It's momentum.",
+  "Reach out. Understand. Let essence flow."
+];
+
+export const IntroNarration: React.FC<{ lines?: string[] }> = ({ lines = defaultLines }) => {
+  const dispatch = useAppDispatch();
+  const hasSeen = useAppSelector(selectHasSeenIntro);
+  const [index, setIndex] = useState(0);
+  if (hasSeen) return null;
+  const last = index === lines.length - 1;
+  return (
+    <Backdrop open sx={{ zIndex: (t) => t.zIndex.drawer + 10, backdropFilter: 'blur(2px)', backgroundColor: 'rgba(0,0,0,0.7)' }}>
+      <Fade in>
+        <Paper elevation={4} sx={{ maxWidth: 640, p: 4, mx: 2 }}>
+          <Typography variant="body1" sx={{ mb: 3, whiteSpace: 'pre-line' }}>
+            {lines[index]}
+          </Typography>
+          <Box textAlign="right">
+            <Button
+              variant="contained"
+              color={last ? 'secondary' : 'primary'}
+              onClick={() => {
+                if (!last) setIndex(i => i + 1); else dispatch(setHasSeenIntro(true));
+              }}
+            >
+              {last ? 'Begin' : 'Continue'}
+            </Button>
+          </Box>
+        </Paper>
+      </Fade>
+    </Backdrop>
+  );
+};
+
+export default IntroNarration;


### PR DESCRIPTION
Introduce a new game flow with a single Elder Willow NPC, reset player state, and implement an introductory narration. Enhance state management for intro visibility and improve essence cost handling. Add a stat difference hook and delta display for better gameplay feedback.